### PR TITLE
Address code review comments from blin (SOFTWARE-4719)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+The OSG Token Renewal Service
+----------------------------- 
+
+The OSG token renewal service is set up as a "oneshot" systemd service,
+which runs under the `osg-token-svc` user, sets up an `oidc-agent`,
+adds the relevant OIDC client accounts as specified in the `config.ini`
+with `oidc-add`, and generates the tokens with `oidc-token`.
+
+This service is set to run via a systemd timer approximately every 15 minutes.
+
+If you would like to run the service manually at a different time (e.g., to generate
+all the tokens immediately), you can run the service once with:
+
+```console
+root@host # systemctl start osg-token-renewer
+```
+
+If this succeeds, the new token will be written to the location you configured
+for `token_path` (`/etc/osg/tokens/<ACCOUNT_SHORTNAME>.token`, by convention).
+
+Failures can be diagnosed by running:
+
+```console
+root@host # journalctl -eu osg-token-renewer
+```
+
+
+Configuring the OSG Token Renewal Service
+----------------------------------------- 
+
+The main configuration file for the service is `/osg/token-renewer/config.ini`.
+
+For each OIDC Client, you will add an `account` section to the config file.
+For each token you wish to generate for this client account,
+you will configure a `token` section with any relevant options.
+
+Examples of this can be found in the `/osg/token-renewer/config.ini` that gets
+installed with the package.
+
+Each `[account <ACCOUNT_SHORTNAME>]` section corresponds to a client account
+named `<ACCOUNT_SHORTNAME>`, set up with the `oidc-gen` tool, run by the
+`osg-token-renewer-setup.sh` script.
+
+In this `account` section, the `password_file` option is a path to a file
+you create as `root` with the encryption password to be used for this client
+account.
+
+Details for this configuration can be found below under
+[Configuring tokens](#configuring-tokens).
+
+For each client account, you can configure one or more `[token <TOKEN_NAME>]`
+sections, where `<TOKEN_NAME>` is a unique name of your choosing.
+These sections describe how to create the token with the `oidc-token` tool.
+For details, see
+[Creating a new OIDC Client Account](#creating-a-new-oidc-client-account)
+below.
+
+

--- a/osg-token-renewer.py
+++ b/osg-token-renewer.py
@@ -46,7 +46,7 @@ def validate_config_dict(cfgx):
             return emsg(f"token {token}: missing 'account {account}' section")
         elif not cfgx["account"][account].get("password_file"):
             return emsg(f"account {account}: missing 'password_file' attribute")
-        elif not cfgx["token"][token].get("token_path")
+        elif not cfgx["token"][token].get("token_path"):
             return emsg(f"token {token}: missing 'token_path' attribute")
 
     return True

--- a/osg-token-renewer.py
+++ b/osg-token-renewer.py
@@ -49,6 +49,10 @@ def validate_config_dict(cfgx):
             print("account %s: missing 'password_file' attribute" % account,
                   file=sys.stderr)
             return False
+        elif not cfgx["token"][token].get("token_path")
+            print("token %s: missing 'token_path' attribute" % token,
+                  file=sys.stderr)
+            return False
 
     return True
 

--- a/osg-token-renewer.py
+++ b/osg-token-renewer.py
@@ -16,14 +16,17 @@ OIDC_SOCK   = '/var/run/osg-token-renewer/oidc-agent'
 # oidc-token --aud="<SERVER AUDIENCE>" <CLIENT NAME>
 
 
+def emsg(msg):
+    print(msg, file=sys.stderr)
+
+
 def get_config_dict(config):
     cfgx = dict(account={}, token={})
 
     for sec in config.sections():
         ss = sec.split()
         if len(ss) != 2 or ss[0] not in cfgx:
-            print("Unrecognized section '%s'" % sec, file=sys.stderr)
-            return None
+            return emsg(f"Unrecognized section '{sec}'")
         type_, name = ss
         cfgx[type_][name] = config[sec]
 
@@ -38,21 +41,13 @@ def validate_config_dict(cfgx):
     for token in cfgx["token"]:
         account = cfgx["token"][token].get("account")
         if not account:
-            print("token %s: missing 'account' attribute" % token,
-                  file=sys.stderr)
-            return False
+            return emsg(f"token {token}: missing 'account' attribute")
         elif account not in cfgx["account"]:
-            print("token %s: missing 'account %s' section" % (token, account),
-                  file=sys.stderr)
-            return False
+            return emsg(f"token {token}: missing 'account {account}' section")
         elif not cfgx["account"][account].get("password_file"):
-            print("account %s: missing 'password_file' attribute" % account,
-                  file=sys.stderr)
-            return False
+            return emsg(f"account {account}: missing 'password_file' attribute")
         elif not cfgx["token"][token].get("token_path")
-            print("token %s: missing 'token_path' attribute" % token,
-                  file=sys.stderr)
-            return False
+            return emsg(f"token {token}: missing 'token_path' attribute")
 
     return True
 
@@ -103,8 +98,7 @@ def mktoken(cfg):
         with open(dest, "wb") as w:
             w.write(token_blob)
     else:
-        print("No token generated for account '%s'" % account[0],
-              file=sys.stderr)
+        emsg(f"No token generated for account '{account[0]}'")
 
 
 def add_account(acct, pwfile):

--- a/osg-token-renewer.py
+++ b/osg-token-renewer.py
@@ -89,9 +89,6 @@ def make_all_tokens(cfgx):
 
     for t in tokens:
         print("token %s" % t)
-        for k,v in tokens[t].items():
-            print("{}: {}".format(k,v))
-        print("---")
         try:
             mktoken(tokens[t])
         except subprocess.CalledProcessError as e:
@@ -100,8 +97,6 @@ def make_all_tokens(cfgx):
         except IOError as e:
             emsg(f"Failed to write token '{t}': {e}")
             errors += 1
-
-        print("===")
 
         return errors
 

--- a/osg-token-renewer.py
+++ b/osg-token-renewer.py
@@ -68,14 +68,28 @@ def add_all_accounts(cfgx):
 
 def make_all_tokens(cfgx):
     tokens = cfgx["token"]
+    errors = 0
 
     for t in tokens:
         print("token %s" % t)
         for k,v in tokens[t].items():
             print("{}: {}".format(k,v))
         print("---")
-        mktoken(tokens[t])
+        try:
+            mktoken(tokens[t])
+        except subprocess.CalledProcessError as e:
+            emsg(f"Failed to create token '{t}': {e}")
+            errors += 1
+        except subprocess.CalledProcessError as e:
+            emsg(f"Failed to create token '{t}': {e}")
+            errors += 1
+        except IOError as e:
+            emsg(f"Failed to write token '{t}': {e}")
+            errors += 1
+
         print("===")
+
+        return errors
 
 
 def option_if(name, val):
@@ -131,10 +145,13 @@ def main():
     if not cfgx or not validate_config_dict(cfgx):
         sys.exit(1)
 
+    errors = 0
     add_all_accounts(cfgx)
-    make_all_tokens(cfgx)
+    errors += make_all_tokens(cfgx)
+
+    return errors
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main() > 1)
 

--- a/osg-token-renewer.py
+++ b/osg-token-renewer.py
@@ -87,9 +87,6 @@ def make_all_tokens(cfgx):
         except subprocess.CalledProcessError as e:
             emsg(f"Failed to create token '{t}': {e}")
             errors += 1
-        except subprocess.CalledProcessError as e:
-            emsg(f"Failed to create token '{t}': {e}")
-            errors += 1
         except IOError as e:
             emsg(f"Failed to write token '{t}': {e}")
             errors += 1

--- a/osg-token-renewer.py
+++ b/osg-token-renewer.py
@@ -26,7 +26,7 @@ def get_config_dict(config):
     for sec in config.sections():
         ss = sec.split()
         if len(ss) != 2 or ss[0] not in cfgx:
-            return emsg(f"Unrecognized section '{sec}'")
+            return emsg(f"Unrecognized configuration section '{sec}'")
         type_, name = ss
         cfgx[type_][name] = config[sec]
 
@@ -156,5 +156,5 @@ def main():
 
 
 if __name__ == '__main__':
-    sys.exit(main() > 1)
+    sys.exit(main() > 0)
 

--- a/osg-token-renewer.py
+++ b/osg-token-renewer.py
@@ -55,6 +55,7 @@ def validate_config_dict(cfgx):
 def add_all_accounts(cfgx):
     accounts = cfgx["account"]
     added = set()
+    errors = 0
 
     for token in cfgx["token"]:
         acct = cfgx["token"][token].get("account")
@@ -62,8 +63,14 @@ def add_all_accounts(cfgx):
             continue
         print("account %s" % acct)
         pwfile = accounts[acct]['password_file']
-        add_account(acct, pwfile)
+        try:
+            add_account(acct, pwfile)
+        except subprocess.CalledProcessError as e:
+            emsg(f"Failed to create account '{acct}': {e}")
+            errors += 1
         added.add(acct)
+
+    return errors
 
 
 def make_all_tokens(cfgx):
@@ -145,8 +152,7 @@ def main():
     if not cfgx or not validate_config_dict(cfgx):
         sys.exit(1)
 
-    errors = 0
-    add_all_accounts(cfgx)
+    errors = add_all_accounts(cfgx)
     errors += make_all_tokens(cfgx)
 
     return errors

--- a/osg-token-renewer.timer
+++ b/osg-token-renewer.timer
@@ -1,8 +1,10 @@
 [Unit]
-Description=Renew proxy every day at midnight
+Description=Timer for running OSG Token Renewer regularly
    
 [Timer]
-OnCalendar=*-*-* 00:00:00
+OnBootSec=15min
+OnUnitActiveSec=15min
+RandomizedDelaySec=3min
 Unit=osg-token-renewer.service
    
 [Install]

--- a/rpm/osg-token-renewer.spec
+++ b/rpm/osg-token-renewer.spec
@@ -1,6 +1,6 @@
 Name:      osg-token-renewer
 Summary:   oidc-agent token renewal service and timer
-Version:   0.1
+Version:   0.2
 Release:   1%{?dist}
 License:   ASL 2.0
 URL:       http://www.opensciencegrid.org
@@ -65,6 +65,13 @@ getent passwd %svc_acct >/dev/null || \
 %attr(-,root,%svc_acct) %config(noreplace) %{_sysconfdir}/osg/token-renewer/config.ini
 
 %changelog
+* Fri Sep 10 2021 Carl Edquist <edquist@cs.wisc.edu> - 0.2-1
+- Address code review comments (SOFTWARE-4719)
+  - Improve config validation & error messages
+  - Improve error handling; continue on errors
+  - Increase the systemd timer frequency
+- Add README leftovers from usage doc (SOFTWARE-4763)
+
 * Tue Aug 17 2021 Carl Edquist <edquist@cs.wisc.edu> - 0.1-1
 - Initial pre-release
 


### PR DESCRIPTION
In SOFTWARE-4719, @brianhlin reviews the current (`v0.1`-ish) codebase, saying:

1. I'd prefer if the script raised more exceptions so that issues could be bubbled up the call chain as appropriate
    1. If we raised exceptions in `add_account` on failure, we could avoid that account when generating tokens
    1. We could give better errors messages by differentiating between write failure and `oidc-token` failure in `mktoken`
1. `mktoken` depends on `token_path` in each token section but that's not checked in the config validation
1. There's no exception handling for `subprocess.check_output()`. It looks like we also throw away stderr from the commands, which could be helpful if logged
1. It looks like `/etc/osg/tokens/` would be owned by root. Will the service account be able to write to it?
1. We should renew the tokens more frequently (discussion already happening here): https://github.com/opensciencegrid/osg-token-renewer/commit/6dceb5b5464a204b03c95bd17cb9ae49ed68ca99#r55545319
1. It looks like we're mostly doing this already but we should try to get as far as we can with each token: meaning if there's a bad config section, an issue adding an account or, token writing failure we should note it and attempt to generate all the other tokens, then exit non-zero. We've been bitten by `gwms_renew_proxies.py` failing early in the past.
