### PR TITLE
use AmbientCapabilities instead of Capabilities (SOFTWARE-4719)

### DIFF
--- a/osg-token-renewer.service
+++ b/osg-token-renewer.service
@@ -10,8 +10,7 @@ ExecStart = /usr/bin/osg-token-renewer.sh
 # These provide dedicated user with the ability to switch UIDs/GIDs for
 # reading/writing files.
 CapabilityBoundingSet=CAP_SETUID CAP_SETGID CAP_DAC_OVERRIDE
-Capabilities=CAP_SETGID+ep CAP_SETUID+ep
-SecureBits=keep-caps
+AmbientCapabilities=CAP_SETGID CAP_SETUID CAP_DAC_OVERRIDE
 
 [Install]
 WantedBy=multi-user.target

--- a/rpm/osg-token-renewer.spec
+++ b/rpm/osg-token-renewer.spec
@@ -1,6 +1,6 @@
 Name:      osg-token-renewer
 Summary:   oidc-agent token renewal service and timer
-Version:   0.5
+Version:   0.6
 Release:   1%{?dist}
 License:   ASL 2.0
 URL:       http://www.opensciencegrid.org
@@ -67,6 +67,9 @@ getent passwd %svc_acct >/dev/null || \
 %attr(-,%svc_acct,%svc_acct) %dir %{_localstatedir}/spool/%svc_acct
 
 %changelog
+* Wed Sep 22 2021 Carl Edquist <edquist@cs.wisc.edu> - 0.6-1
+- Set AmbientCapabilities in systemd unit, for child processes (SOFTWARE-4719)
+
 * Mon Sep 20 2021 Carl Edquist <edquist@cs.wisc.edu> - 0.5-1
 - Fixes for example config and setup script (SOFTWARE-4719)
 


### PR DESCRIPTION
this fixes the

```
[Errno 13] Permission denied: '/etc/osg/tokens/myclient1234.pw'
```

errors the service was getting previously.

...

For reference, i found the `AmbientCapabilities` option documented here:

https://www.freedesktop.org/software/systemd/man/systemd.exec.html