### PR TITLE
Fix faulty script exit status (SOFTWARE-4719)

### DIFF
--- a/osg-token-renewer.sh
+++ b/osg-token-renewer.sh
@@ -6,7 +6,11 @@ oidc-agent -k >/dev/null
 
 # oidc-agent does not clean up its old socket files, apparently
 if [[ $OIDC_SOCK = /tmp/oidc-*/oidc-agent.* ]]; then
-  [[ -e $OIDC_SOCK ]] && rm -f "$OIDC_SOCK"
-  [[ -d ${OIDC_SOCK%/*} ]] && rmdir "${OIDC_SOCK%/*}"
+  if [[ -e $OIDC_SOCK ]]; then
+    rm -f "$OIDC_SOCK"
+  fi
+  if [[ -d ${OIDC_SOCK%/*} ]]; then
+    rmdir "${OIDC_SOCK%/*}"
+  fi
 fi
 

--- a/rpm/osg-token-renewer.spec
+++ b/rpm/osg-token-renewer.spec
@@ -1,7 +1,7 @@
 Name:      osg-token-renewer
 Summary:   oidc-agent token renewal service and timer
-Version:   0.6
-Release:   2%{?dist}
+Version:   0.7
+Release:   1%{?dist}
 License:   ASL 2.0
 URL:       http://www.opensciencegrid.org
 BuildArch: noarch
@@ -67,6 +67,9 @@ getent passwd %svc_acct >/dev/null || \
 %attr(-,%svc_acct,%svc_acct) %dir %{_localstatedir}/spool/%svc_acct
 
 %changelog
+* Tue Sep 28 2021 Carl Edquist <edquist@cs.wisc.edu> - 0.7-1
+- Fix exit status for main service script (SOFTWARE-4719)
+
 * Tue Sep 28 2021 Carl Edquist <edquist@cs.wisc.edu> - 0.6-2
 - Drop .sh suffix on setup script
 


### PR DESCRIPTION
Oldest gotcha in the book!

You don't want the last statement in your script to be a

```
  [[ ... ]] && do something
```

because if the condition fails, then `$?` is set to 1, which ends up being the script exit status.

You can fix this by changing it to

```
  [[ ! ... ]] || do something
```

Although in this case i think it makes it awkward to read.

I prefer two lines to six, but in this case the long-winded if-blocks are more readable and avoid this issue with `&&`.

the exit status of the script mainly matters because, even though the service will complete its work regardless, systemd will be tricked into thinking it does not work.

