### PR TITLE
Add manual client registration (SOFTWARE-4983)

### DIFF
--- a/osg-token-renewer-setup.sh
+++ b/osg-token-renewer-setup.sh
@@ -13,7 +13,8 @@ usage () {
   echo "  --manual                     Manual client registration"
   exit 1
 }
-
+pwfile=
+manual=
 while [[ $1 = -* ]]; do
 case $1 in
   --pw-file ) pwfile=$2; shift 2 ;;

--- a/osg-token-renewer-setup.sh
+++ b/osg-token-renewer-setup.sh
@@ -9,13 +9,15 @@ usage () {
   echo "   eg: $(basename "$0") myclient123"
   echo
   echo "Options:"
-  echo "  --pw-file /path/to/pwfile"
+  echo "  --pw-file /path/to/pwfile    Specify a password file"
+  echo "  --manual                     Manual client registration"
   exit 1
 }
 
 while [[ $1 = -* ]]; do
 case $1 in
   --pw-file ) pwfile=$2; shift 2 ;;
+  --manual  ) manual='--manual'; shift 1 ;;
    -*       ) usage ;;
 esac
 done
@@ -40,13 +42,13 @@ fail "please create /etc/osg/tokens/$client_name.pw with encryption password"
 if [[ $UID = 0 ]]; then
   # open $pwfile as root, then re-run this script under service account
   exec su osg-token-svc -s /bin/bash -c '"$@"' -- - \
-  "$0" --pw-file /dev/fd/9 "$client_name"
+  "$0" $manual --pw-file /dev/fd/9 "$client_name"
 fi 9<"$pwfile"
 
 eval $(oidc-agent)
 trap cleanup EXIT
 
-oidc-gen -w device --pw-cmd="cat '$pwfile'" "$client_name"
+oidc-gen -w device $manual --pw-cmd="cat '$pwfile'" "$client_name"
 
 echo
 echo


### PR DESCRIPTION
Resolves #13 

The option passing to `oidc-gen` is a little superfluous but this gets the job done. I'm currently planning to do a bit of cleanup with this follow on ticket. https://opensciencegrid.atlassian.net/browse/SOFTWARE-5050

```
[root@f25eb75d434c /]# osg-token-renewer-setup --manual --pw-file pass test123
Agent pid 140
/usr/local/bin/oidc-gen: line 2: /tmp/oidc-agent.env: No such file or directory
No account exists with this short name. Creating new configuration ...
[1] https://iam-test.indigo-datacloud.eu/
[2] https://iam.deep-hybrid-datacloud.eu/
[3] https://iam.extreme-datacloud.eu/
[4] https://iam-demo.cloud.cnaf.infn.it/
[5] https://b2access.eudat.eu/oauth2/
[6] https://b2access-integration.fz-juelich.de/oauth2
[7] https://login-dev.helmholtz.de/oauth2/
[8] https://login.helmholtz.de/oauth2/
[9] https://services.humanbrainproject.eu/oidc/
[10] https://accounts.google.com/
[11] https://aai.egi.eu/oidc/
[12] https://aai-demo.egi.eu/oidc/
[13] https://aai-dev.egi.eu/oidc
[14] https://login.elixir-czech.org/oidc/
[15] https://oidc.scc.kit.edu/auth/realms/kit/
[16] https://wlcg.cloud.cnaf.infn.it/
Issuer [https://iam-test.indigo-datacloud.eu/]: 16
Client_id: dcdf4d60-465f-469a-837c-f69ccb618121
Client_secret: 
The following scopes are supported: openid profile email offline_access wlcg wlcg.groups storage.read:/ storage.create:/ compute.read compute.modify compute.create compute.cancel storage.modify:/ eduperson_scoped_affiliation eduperson_entitlement
Scopes or 'max' (space separated) [openid profile offline_access]: max
Redirect_uris (space separated): 
Generating account configuration ...
accepted

Using a browser on any device, visit:
https://wlcg.cloud.cnaf.infn.it/device

And enter the code: <snip>
Alternatively you can use the following QR code to visit the above listed URL.

Everything setup correctly!

Add the following section to /etc/osg/token-renewer/config.ini :

[account test123]

password_file = /etc/osg/tokens/test123.pw
```
