### PR TITLE
Fixes for the CILogon token issuer

### DIFF
--- a/osg-token-renewer.py
+++ b/osg-token-renewer.py
@@ -113,8 +113,6 @@ def mktoken(cfg):
     if scope == []:
         # A blank scope tells oidc-token to request the default scopes of
         # the refresh token instead of re-requesting the original scopes.
-        # (This is temporarily -- until April '22 -- needed by the CILogon
-        # issuer and generally a better way to do this).
         scope = ["--scope", " "]
     time    = option_if('time',  cfg.get("min_lifetime"))
     account = [cfg.get("account")]

--- a/osg-token-renewer.py
+++ b/osg-token-renewer.py
@@ -110,6 +110,12 @@ def mktoken(cfg):
     prog    = ['oidc-token']
     aud     = option_if('aud',   cfg.get("audience")    )
     scope   = option_if('scope', cfg.get("scope")       )
+    if scope == []:
+        # A blank scope tells oidc-token to request the default scopes of
+        # the refresh token instead of re-requesting the original scopes.
+        # (This is temporarily -- until April '22 -- needed by the CILogon
+        # issuer and generally a better way to do this).
+        scope = ["--scope", " "]
     time    = option_if('time',  cfg.get("min_lifetime"))
     account = [cfg.get("account")]
     cmdline = prog + aud + scope + time + account

--- a/osg-token-renewer.py
+++ b/osg-token-renewer.py
@@ -126,7 +126,9 @@ def mktoken(cfg):
 
 def add_account(acct, pwfile):
     pwcmd = "cat '%s'" % pwfile.replace("'", r"'\''")
-    cmd = ["oidc-add", "--pw-cmd=%s" % pwcmd, acct]
+    # --pw-store is needed for issuers like CILogon that make a new
+    # refresh token every time an access token is requested
+    cmd = ["oidc-add", "--pw-store", "--pw-cmd=%s" % pwcmd, acct]
     out = subprocess.check_output(cmd).strip().decode('utf-8')
     print("# oidc-add ... %s (%s)" % (acct, out))
 

--- a/rpm/osg-token-renewer.spec
+++ b/rpm/osg-token-renewer.spec
@@ -1,6 +1,6 @@
 Name:      osg-token-renewer
 Summary:   oidc-agent token renewal service and timer
-Version:   0.8.0
+Version:   0.8.1
 Release:   1%{?dist}
 License:   ASL 2.0
 URL:       http://www.opensciencegrid.org
@@ -71,6 +71,11 @@ getent passwd %svc_acct >/dev/null || \
 
 
 %changelog
+* Mon Mar 14 2022 Brian Lin <blin@cs.wisc.edu> - 0.8.1-1
+- Add the --pw-store option to the invocation of oidc-add and add a default
+  scope of blank if no scopes are configured.  These are needed for the
+  CILogon issuer (SOFTWARE-4983).
+
 * Fri Feb 25 2022 Brian Lin <blin@cs.wisc.edu> - 0.8.0-1
 - Add support for manual client registration (SOFTWARE-4983)
 


### PR DESCRIPTION
This adds the `--pw-store` option to the oidc-add invocation and `--scope " "` to oidc-token if no scopes are specified.  The former enables storing of updated refresh tokens which CILogon sends, and the latter prevents oidc-token from resending the default scopes which currently confuses CILogon.