### PR TITLE
Use oidc-add --pw-file option from newer versions (SOFTWARE-5050)

### DIFF
--- a/osg-token-renewer-setup.sh
+++ b/osg-token-renewer-setup.sh
@@ -49,6 +49,10 @@ cleanup () {
 [[ -e $pwfile ]] ||
 fail "please create /etc/osg/tokens/$client_name.pw with encryption password"
 
+# Note: cannot pass --pw-file option to the script run as the service account,
+# as the service account may not have access to open the file by name for
+# reading.  Instead, we open the file as root for the service account process
+# to inherit the already-open file descriptor.
 if [[ $UID = 0 ]]; then
   # open $pwfile as root, then re-run this script under service account
   exec su osg-token-svc -s /bin/bash -c '"$@"' -- - \

--- a/osg-token-renewer.py
+++ b/osg-token-renewer.py
@@ -11,7 +11,7 @@ OIDC_SOCK   = '/var/run/osg-token-renewer/oidc-agent'
 #As root, the user runs oidc-gen -w device ACCOUNT_SHORTNAME
 
 # oidc-gen -w device ClientNameo
-# - misc prompts, including password, which can be got with --pw-cmd=CMD
+# - misc prompts, including password, which can be got with --pw-file=FILE
 
 # oidc-token --aud="<SERVER AUDIENCE>" <CLIENT NAME>
 
@@ -129,10 +129,9 @@ def mktoken(cfg):
 
 
 def add_account(acct, pwfile):
-    pwcmd = "cat '%s'" % pwfile.replace("'", r"'\''")
     # --pw-store is needed for issuers like CILogon that make a new
     # refresh token every time an access token is requested
-    cmd = ["oidc-add", "--pw-store", "--pw-cmd=%s" % pwcmd, acct]
+    cmd = ["oidc-add", "--pw-store", "--pw-file=%s" % pwfile, acct]
     out = subprocess.check_output(cmd).strip().decode('utf-8')
     print("# oidc-add ... %s (%s)" % (acct, out))
 

--- a/rpm/osg-token-renewer.spec
+++ b/rpm/osg-token-renewer.spec
@@ -1,6 +1,6 @@
 Name:      osg-token-renewer
 Summary:   oidc-agent token renewal service and timer
-Version:   0.8.1
+Version:   0.8.2
 Release:   1%{?dist}
 License:   ASL 2.0
 URL:       http://www.opensciencegrid.org
@@ -8,7 +8,7 @@ BuildArch: noarch
 
 Source0:   %{name}-%{version}.tar.gz
 
-Requires:  oidc-agent
+Requires:  oidc-agent >= 4.2.0
 
 %define svc_acct osg-token-svc
 
@@ -71,6 +71,11 @@ getent passwd %svc_acct >/dev/null || \
 
 
 %changelog
+* Fri Apr 15 2022 Carl Edquist <edquist@cs.wisc.edu> - 0.8.2-1
+- Fix password file handling for restricted permissions in setup script (#17)
+- Use newer --pw-file option for oidc-add (SOFTWARE-5050)
+- Bump version requirement for oidc-agent package (SOFTWARE-5050)
+
 * Mon Mar 14 2022 Brian Lin <blin@cs.wisc.edu> - 0.8.1-1
 - Add the --pw-store option to the invocation of oidc-add and add a default
   scope of blank if no scopes are configured.  These are needed for the


### PR DESCRIPTION
Note this works, like the --pw-cmd option used to, because this script
is invoked by systemd, and the service file sets up Capabilities for
the osg-token-svc account to be able to skip permissions checks...

Unfortunately the same is not true for the setup script, which is run
by hand as root, and only is able to provide access to the password
file via an inherited file descriptor.  Thus re-opening the file path
itself (which is implied by --pw-file) will not work when called in
the setup script after it is re-invoked as the service account.