### PR TITLE
Increase renewal frequency to every 10 min (SOFTWARE-5137)

### DIFF
--- a/osg-token-renewer.timer
+++ b/osg-token-renewer.timer
@@ -3,7 +3,7 @@ Description=Timer for running OSG Token Renewer regularly
    
 [Timer]
 OnBootSec=15min
-OnUnitActiveSec=15min
+OnUnitActiveSec=10min
 RandomizedDelaySec=3min
 Unit=osg-token-renewer.service
    

--- a/rpm/osg-token-renewer.spec
+++ b/rpm/osg-token-renewer.spec
@@ -1,6 +1,6 @@
 Name:      osg-token-renewer
 Summary:   oidc-agent token renewal service and timer
-Version:   0.8.1
+Version:   0.8.2
 Release:   1%{?dist}
 License:   ASL 2.0
 URL:       http://www.opensciencegrid.org
@@ -71,6 +71,9 @@ getent passwd %svc_acct >/dev/null || \
 
 
 %changelog
+* Thu Apr 28 2022 Carl Edquist <edquist@cs.wisc.edu> - 0.8.2-1
+- Increase renewal frequency to ensure continual validity (SOFTWARE-5137)
+
 * Mon Mar 14 2022 Brian Lin <blin@cs.wisc.edu> - 0.8.1-1
 - Add the --pw-store option to the invocation of oidc-add and add a default
   scope of blank if no scopes are configured.  These are needed for the


### PR DESCRIPTION
Bockjoo was seeing 15min token lifetimes, which were not quite enough to keep them valid with the 15min renewal frequency + 3min random delay.

I'm open to other suggestions, but my first thought was just to provide a default min lifetime of 1h.

EDIT: We're just going to change the timer to update every 10 min + 3min random delay, as the tokens were coming back with 15 min lifetimes regardless of the min lifetime option being specified.