### PR TITLE
Improve pw file handling for strict permissions (SOFTWARE-5304)

### DIFF
--- a/osg-token-renewer-setup.sh
+++ b/osg-token-renewer-setup.sh
@@ -40,7 +40,6 @@ if [[ $pwfd ]]; then
   if [[ $pwfile ]]; then
     usage "*** The --pw-file and --pw-fd options are mutually exclusive."
   fi
-  pwfile=/dev/fd/$pwfd  # for existence check, not for opening
   [[ -e /dev/fd/$pwfd ]] ||
   fail "password fd $pwfd does not appear to be open"
 else

--- a/osg-token-renewer-setup.sh
+++ b/osg-token-renewer-setup.sh
@@ -64,9 +64,10 @@ cleanup () {
 # to inherit the already-open file descriptor.
 if [[ $UID = 0 ]]; then
   # open $pwfile as root, then re-run this script under service account
-  exec su osg-token-svc -s /bin/bash -c '"$@"' -- - \
-  "$0" $manual --pw-fd 9 "$client_name"
-fi 9<"$pwfile"
+  { exec su osg-token-svc -s /bin/bash -c '"$@"' -- - \
+    "$0" $manual --pw-fd 9 "$client_name"
+  } 9<"$pwfile"
+fi
 
 eval $(oidc-agent)
 trap cleanup EXIT

--- a/rpm/osg-token-renewer.spec
+++ b/rpm/osg-token-renewer.spec
@@ -1,6 +1,6 @@
 Name:      osg-token-renewer
 Summary:   oidc-agent token renewal service and timer
-Version:   0.8.2
+Version:   0.8.3
 Release:   1%{?dist}
 License:   ASL 2.0
 URL:       http://www.opensciencegrid.org
@@ -71,6 +71,9 @@ getent passwd %svc_acct >/dev/null || \
 
 
 %changelog
+* Fri Aug 26 2022 Carl Edquist <edquist@cs.wisc.edu> - 0.8.3-1
+- Handle tighter permissions on tokens dir and pwfile (SOFTWARE-5304)
+
 * Thu Apr 28 2022 Carl Edquist <edquist@cs.wisc.edu> - 0.8.2-1
 - Increase renewal frequency to ensure continual validity (SOFTWARE-5137)
 - Fix password file handling for restricted permissions in setup script (#17)


### PR DESCRIPTION
Allow for:

- tokens dir `0700` perms (no `o+x`)
- pwfile with `0600` perms (no `o+r`)
 
I had though the second item already worked, but reviewing the code gave me doubts, so I've touched that up also.  May be easier to review the separate commits individually.