### PR TITLE
Add client credentials mode

### DIFF
--- a/.github/workflows/python-linters.yml
+++ b/.github/workflows/python-linters.yml
@@ -8,7 +8,7 @@ jobs:
     outputs:
       filelist: ${{ steps.python-files.outputs.filelist }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - id: python-files
       run: |
         echo "filelist=$(find . -type f -exec awk ' /^#!.*python/{print FILENAME} {nextfile}' {} + | tr '\n' ' ')" >> $GITHUB_OUTPUT
@@ -16,25 +16,25 @@ jobs:
     runs-on: ubuntu-latest
     needs: [python-files]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.12
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ~/pip-cache
-        key: pip-3.8-${{ github.sha }}
+        key: pip-3.12-${{ github.sha }}
         # allow cache hits from previous runs of the current branch,
         # parent branch, then upstream branches, in that order
         restore-keys: |
-          pip-3.8-
+          pip-3.12-
     - name: Install Requirements
       run: |
         python -m pip install --upgrade pip
-        pip --cache-dir ~/pip-cache install pylint
+        pip --cache-dir ~/pip-cache install pylint requests PyJWT
     - name: Run Pylint
       env:
         PYTHON_FILES: ${{ needs.python-files.outputs.filelist }}
@@ -46,25 +46,25 @@ jobs:
     runs-on: ubuntu-latest
     needs: [python-files]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.12
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ~/pip-cache
-        key: pip-3.8-${{ github.sha }}
+        key: pip-3.12-${{ github.sha }}
         # allow cache hits from previous runs of the current branch,
         # parent branch, then upstream branches, in that order
         restore-keys: |
-          pip-3.8-
+          pip-3.12-
     - name: Install Requirements
       run: |
         python -m pip install --upgrade pip
-        pip --cache-dir ~/pip-cache install flake8
+        pip --cache-dir ~/pip-cache install flake8 requests PyJWT
     - name: Run flake8
       env:
         PYTHON_FILES: ${{ needs.python-files.outputs.filelist }}

--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
 The OSG Token Renewal Service
 ----------------------------- 
 
-The OSG token renewal service is set up as a "oneshot" systemd service,
-which runs under the `osg-token-svc` user, sets up an `oidc-agent`,
+The OSG token renewal service is set up as a "oneshot" systemd service
+which runs under the `osg-token-svc` user.
+
+It has two basic modes of operation, depending on if the oauth client
+needs to do OIDC authentication or is using the "client credentials"
+grant type.
+
+If it needs to do OIDC authentication, it sets up an `oidc-agent`,
 adds the relevant OIDC client accounts as specified in the `config.ini`
 with `oidc-add`, and generates the tokens with `oidc-token`.
+
+Otherwise with the "client credentials" grant type it simply contacts
+the token issuer and requests a new access token.
 
 This service is set to run via a systemd timer approximately every 15 minutes.
 
@@ -28,30 +37,33 @@ root@host # journalctl -eu osg-token-renewer
 Configuring the OSG Token Renewal Service
 ----------------------------------------- 
 
-The main configuration file for the service is `/osg/token-renewer/config.ini`.
+The main configuration file for the service is `/etc/osg/token-renewer/config.ini`.
 
-For each OIDC Client, you will add an `account` section to the config file.
+For each client, you will add an `account` section to the config file
+as instructed by the `osg-token-renewer-setup` script.
 For each token you wish to generate for this client account,
-you will configure a `token` section with any relevant options.
+you will configure a `token` section with any relevant options by hand.
 
-Examples of this can be found in the `/osg/token-renewer/config.ini` that gets
-installed with the package.
+Examples of this can be found in the `/etc/osg/token-renewer/config.ini`
+that gets installed with the package.
 
 Each `[account <ACCOUNT_SHORTNAME>]` section corresponds to a client account
-named `<ACCOUNT_SHORTNAME>`, set up with the `oidc-gen` tool, run by the
-`osg-token-renewer-setup.sh` script.
+named `<ACCOUNT_SHORTNAME>`, defined in the `osg-token-renewer-setup` script.
 
-In this `account` section, the `password_file` option is a path to a file
-you create as `root` with the encryption password to be used for this client
-account.
+When using OIDC mode, the `account` section only contains a `password_file`
+option which is a path to a file you create as `root` with the password
+to be used to encrypt the information for that client account.
+
+When using the client credentials mode, the `account` section contains a
+`token_request_url`, `client_id`, and `client_secret`.
 
 Details for this configuration can be found in the
-[documentation here](https://opensciencegrid.org/docs/other/osg-token-renewer/#configuring-tokens).
+[documentation here](https://osg-htc.org/docs/other/osg-token-renewer/#configuring-accounts).
 
 For each client account, you can configure one or more `[token <TOKEN_NAME>]`
 sections, where `<TOKEN_NAME>` is a unique name of your choosing.
-These sections describe how to create the token with the `oidc-token` tool.
+These sections define the path to a file to store the token and optional
+parameters to use when requesting it.
 For details, see the 
-[documentation here](https://opensciencegrid.org/docs/other/osg-token-renewer/#configuring-accounts).
-
+[documentation here](https://osg-htc.org/docs/other/osg-token-renewer/#configuring-tokens).
 

--- a/config.ini
+++ b/config.ini
@@ -1,20 +1,32 @@
-[account ACCOUNT_SHORTNAME]
+# Example OIDC authentication account
+#
+# [account ACCOUNT_SHORTNAME]
+# 
+# password_file = /etc/osg/tokens/ACCOUNT_SHORTNAME.pw
+# 
 
-password_file = /etc/osg/tokens/ACCOUNT_SHORTNAME.pw
+# Example client credentials account
+#
+# [account ACCOUNT_SHORTNAME]
+# 
+# token_request_url = https://demo.scitokens.org/oauth2/token
+# client_id = PROVIDED_CLIENT_ID
+# client_secret = PROVIDED_CLIENT_SECRET
+# 
 
-
-
-[token TOKEN_NAME]
-
-account = ACCOUNT_SHORTNAME
-token_path = /etc/osg/tokens/ACCOUNT_SHORTNAME.TOKEN_NAME.token
-
+# Example token description
+#
+# [token TOKEN_NAME]
+# 
+# account = ACCOUNT_SHORTNAME
+# token_path = /etc/osg/tokens/ACCOUNT_SHORTNAME.TOKEN_NAME.token
+#
 # Optional:
 #
-# audience = <list of audiences to pass via --aud option>
+# audience = <list of audiences to request>
 # (For tokens used against an HTCondor-CE, set to <CE FQDN>:<CE PORT>)
 #
-# scope = <list of scopes to pass via --scope option>
+# scope = <list of scopes to request>
 #
-# min_lifetime = <min token lifetime in seconds to pass via --time option>
-
+# min_lifetime = <minimum lifetime in seconds to remain in token>
+#  (default: get a new token every time the timer runs)

--- a/osg-token-renewer-setup.sh
+++ b/osg-token-renewer-setup.sh
@@ -14,18 +14,21 @@ usage () {
   echo
   echo "Options:"
   echo "  --pw-file /path/to/pwfile    Specify a password file"
-  echo "  --manual                     Manual client registration"
+  echo "  --manual                     Manual OIDC client registration"
+  echo "  --client-credentials         Set up for client credentials grant type"
   exit 1
 }
 
 pwfile=
 pwfd=
 manual=
+client_credentials=
 while [[ $1 = -* ]]; do
 case $1 in
   --pw-file ) pwfile=$2; shift 2 ;;
   --pw-fd   ) pwfd=$2;   shift 2 ;;  # internal option only
-  --manual  ) manual='--manual'; shift 1 ;;
+  --manual  ) manual=$1; shift 1 ;;
+  --client-credentials) client_credentials=$1; shift 1 ;;
    -*       ) usage ;;
 esac
 done
@@ -36,6 +39,38 @@ done
 [[ $UID = 0 || $USER = osg-token-svc ]] || usage '*** Please run as root!'
 
 client_name=$1
+
+if [ -n "$client_credentials" ]; then
+  echo -n "Token issuer url: "
+  read TOKEN_ISSUER
+  OPENID_URL="$TOKEN_ISSUER/.well-known/openid-configuration"
+  if ! OUT="$(curl -fsS -m 5 "$OPENID_URL")"; then
+    echo "Failure reading from $OPENID_URL" >&2
+    exit 1
+  fi
+  if ! token_request_url="$(echo "$OUT" | jq -er .token_endpoint)"; then
+    echo "Failure decoding token_endpoint from $OPENID_URL output" >&2
+    exit 1
+  fi
+  echo -n "Client id: "
+  read client_id
+  echo -n "Secret: "
+  read client_secret
+  
+  echo
+  echo
+  echo "Add the following section to /etc/osg/token-renewer/config.ini :"
+  echo
+  echo "[account $client_name]"
+  echo
+  echo "token_request_url = $token_request_url"
+  echo "client_id = $client_id"
+  echo "client_secret = $client_secret"
+  echo
+
+  exit 0
+fi
+
 if [[ $pwfd ]]; then
   if [[ $pwfile ]]; then
     usage "*** The --pw-file and --pw-fd options are mutually exclusive."
@@ -46,7 +81,18 @@ else
   [[ $pwfile ]] || pwfile=/etc/osg/tokens/$client_name.pw
 
   [[ -e $pwfile ]] ||
-  fail "please create /etc/osg/tokens/$client_name.pw with encryption password"
+  fail "please create $pwfile with encryption password"
+fi
+
+# Note: cannot pass --pw-file option to the script run as the service account,
+# as the service account may not have access to open the file by name for
+# reading.  Instead, we open the file as root for the service account process
+# to inherit the already-open file descriptor.
+if [[ $UID = 0 ]]; then
+  # open $pwfile as root, then re-run this script under service account
+  { exec su osg-token-svc -s /bin/bash -c '"$@"' -- - \
+    "$0" $manual $client_credentials --pw-fd 9 "$client_name"
+  } 9<"$pwfile"
 fi
 
 cleanup () {
@@ -56,17 +102,6 @@ cleanup () {
     [[ -d ${OIDC_SOCK%/*} ]] && rmdir "${OIDC_SOCK%/*}"
   fi
 }
-
-# Note: cannot pass --pw-file option to the script run as the service account,
-# as the service account may not have access to open the file by name for
-# reading.  Instead, we open the file as root for the service account process
-# to inherit the already-open file descriptor.
-if [[ $UID = 0 ]]; then
-  # open $pwfile as root, then re-run this script under service account
-  { exec su osg-token-svc -s /bin/bash -c '"$@"' -- - \
-    "$0" $manual --pw-fd 9 "$client_name"
-  } 9<"$pwfile"
-fi
 
 eval $(oidc-agent)
 trap cleanup EXIT

--- a/osg-token-renewer.py
+++ b/osg-token-renewer.py
@@ -2,6 +2,9 @@
 
 import configparser
 import subprocess
+import requests
+import jwt
+import time
 import sys
 import os
 
@@ -29,6 +32,7 @@ def get_config_dict(config):
             return emsg(f"Unrecognized config section '{sec}'")
         type_, name = ss
         cfgx[type_][name] = config[sec]
+        cfgx[type_][name]['name'] = name
 
     return cfgx
 
@@ -39,14 +43,20 @@ E_NO_TOK_ACCT_SEC  = (
     "Config for [token {token}]: missing [account {account}] section")
 E_NO_TOK_PATH_ATTR = (
     "Config section [token {token}]: missing 'token_path' attribute")
-E_NO_ACCT_PW_ATTR  = (
-    "Config section [account {account}]: missing 'password_file' attribute")
+E_NO_ACCT_PW_OR_TRU_ATTR  = (
+    "Config section [account {account}]: missing both 'password_file' and 'token_request_url' attributes")
+E_NO_ACCT_CI_ATTR  = (
+    "Config section [account {account}]: missing 'client_id'")
+E_NO_ACCT_CS_ATTR  = (
+    "Config section [account {account}]: missing 'client_secret'")
+
 
 def validate_config_dict(cfgx):
     # the only mandatory attributes here are:
     #  - [token TOKEN].account exists, and references [account ACCOUNT]
     #  - [token TOKEN].token_path exists
-    #  - [account ACCOUNT].password_file exists
+    #  - [account ACCOUNT].password_file or [account ACCOUNT].token_request_url 
+    #    exists
 
     for token in cfgx["token"]:
         account = cfgx["token"][token].get("account")
@@ -57,7 +67,13 @@ def validate_config_dict(cfgx):
         elif not cfgx["token"][token].get("token_path"):
             return emsg(E_NO_TOK_PATH_ATTR, token=token)
         elif not cfgx["account"][account].get("password_file"):
-            return emsg(E_NO_ACCT_PW_ATTR, account=account)
+            if cfgx["account"][account].get("token_request_url"):
+                if not cfgx["account"][account].get("client_id"):
+                    return emsg(E_NO_ACCT_CI_ATTR, account=account)
+                elif not cfgx["account"][account].get("client_secret"):
+                    return emsg(E_NO_ACCT_CS_ATTR, account=account)
+            else:
+                return emsg(E_NO_ACCT_PW_OR_TRU_ATTR, account=account)
 
     return True
 
@@ -72,31 +88,26 @@ def add_all_accounts(cfgx):
         if acct in added:
             continue
         print("account %s" % acct)
-        pwfile = accounts[acct]['password_file']
-        try:
-            add_account(acct, pwfile)
-        except subprocess.CalledProcessError as e:
-            emsg(f"Failed to create account '{acct}': {e}")
-            errors += 1
+        if 'password_file' in accounts[acct]:
+            pwfile = accounts[acct]['password_file']
+            errors += add_account(acct, pwfile)
         added.add(acct)
 
     return errors
 
 
 def make_all_tokens(cfgx):
+    accounts = cfgx["account"]
     tokens = cfgx["token"]
     errors = 0
 
-    for t in tokens:
-        print("token %s" % t)
-        try:
-            mktoken(tokens[t])
-        except subprocess.CalledProcessError as e:
-            emsg(f"Failed to create token '{t}': {e}")
-            errors += 1
-        except IOError as e:
-            emsg(f"Failed to write token '{t}': {e}")
-            errors += 1
+    for token in tokens:
+        print("token %s" % token)
+        account = accounts[cfgx["token"][token].get("account")]
+        if 'password_file' in account:
+            errors += mk_oidc_token(tokens[token])
+        else:
+            errors += request_token(account, tokens[token])
 
     return errors
 
@@ -105,7 +116,20 @@ def option_if(name, val):
     return ['--{}={}'.format(name, val)] if val else []
 
 
-def mktoken(cfg):
+def write_token(cfg, token_blob):
+    dest    = cfg.get("token_path")
+    print("> %s" % dest)
+    try:
+        fd = os.open(dest, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "wb+") as w:
+            w.write(token_blob)
+    except Exception as e:
+        emsg(f"Failed to write token '{cfg['name']}': {e}")
+        return 1
+    return 0
+
+
+def mk_oidc_token(cfg):
     #oidc-token --aud="<SERVER AUDIENCE>" <CLIENT NAME> > <TOKEN PATH>
     prog    = ['oidc-token']
     aud     = option_if('aud',   cfg.get("audience")    )
@@ -114,18 +138,79 @@ def mktoken(cfg):
         # A blank scope tells oidc-token to request the default scopes of
         # the refresh token instead of re-requesting the original scopes.
         scope = ["--scope", " "]
-    time    = option_if('time',  cfg.get("min_lifetime"))
-    account = [cfg.get("account")]
-    cmdline = prog + aud + scope + time + account
-    dest    = cfg.get("token_path")
+    min_lifetime = option_if('time',  cfg.get("min_lifetime"))
+    acct = cfg.get("account")
+    cmdline = prog + aud + scope + min_lifetime + [acct]
     print(cmdline)
-    token_blob = subprocess.check_output(cmdline)
+    t = cfg['name']
+    try:
+        token_blob = subprocess.check_output(cmdline)
+    except Exception as e:
+        emsg(f"Failed to get token '{t}': {e}")
+        return 1
     if token_blob:
-        print("> %s" % dest)
-        with open(dest, "wb") as w:
-            w.write(token_blob)
+        return write_token(cfg, token_blob)
     else:
-        emsg(f"No token generated for account '{account[0]}'")
+        emsg(f"No token '{t}' generated for account '{acct}'")
+        return 1
+
+    return 0
+
+
+def request_token(account, cfg):
+    t = cfg['name']
+    min_lifetime_str = cfg.get("min_lifetime")
+    if min_lifetime_str != None:
+        if not min_lifetime_str.isdigit():
+            emsg(f"min_lifetime for token '{t}' is not a non-negative integer")
+            return 1
+        min_lifetime = int(min_lifetime_str)
+        dest = cfg.get("token_path")
+        try:
+            with open(dest, 'r', encoding='utf-8') as file:
+                oldtok = file.read().strip()
+            options = {
+                "verify_signature": False,
+                "verify_aud": False,
+                "verify_exp": False
+            }
+            exp = jwt.decode(oldtok, options=options)['exp']
+            remaining = exp - int(time.time())
+            if remaining > min_lifetime:
+                emsg(f"{str(remaining)} seconds remaining in '{t}', not renewing")
+                return 0
+        except FileNotFoundError:
+            pass
+        except Exception as e:
+            emsg(f"Couldn't read old '{t}' token expiration time, continuing: {e}")
+
+    data={"grant_type": "client_credentials"}
+    aud = cfg.get("audience")
+    if aud != None:
+        data['audience'] = aud
+    scope = cfg.get("scope")
+    if scope != None:
+        data['scope'] = scope
+
+    try:
+        response = requests.post(
+            account['token_request_url'],
+            headers={'Content-Type': 'application/x-www-form-urlencoded'},
+            data=data,
+            auth=(account['client_id'], account['client_secret']),
+            timeout=10
+        )
+        response.raise_for_status()
+        response_data = response.json()
+    except Exception as e:
+        emsg(f"Failure requesting token '{t}': {e}")
+        return 1
+
+    if 'access_token' not in response_data:
+        emsg(f"No access_token returned in response for token '{t}'")
+        return 1
+    access_token = response_data['access_token'] + '\n'
+    return write_token(cfg, access_token.encode("utf-8"))
 
 
 def add_account(acct, pwfile):
@@ -134,20 +219,13 @@ def add_account(acct, pwfile):
     # --skip-check prevents attempting to get an access token from
     # the token issuer at load time.
     cmd = ["oidc-add", "--skip-check", "--pw-store", "--pw-file=%s" % pwfile, acct]
-    out = subprocess.check_output(cmd).strip().decode('utf-8')
+    try:
+        out = subprocess.check_output(cmd).strip().decode('utf-8')
+    except subprocess.CalledProcessError as e:
+        emsg(f"Failed to create account '{acct}': {e}")
+        return 1
     print("# oidc-add ... %s (%s)" % (acct, out))
-
-
-# handy functions, for potential use later to set file ownership
-#
-#import pwd, grp
-#
-#def get_uid(name):
-#    return pwd.getpwnam(name).pw_uid  # also, .pw_gid
-#
-#
-#def get_gid(gname):
-#    return grp.getgrnam(gname).gr_gid
+    return 0
 
 
 def main():
@@ -168,5 +246,5 @@ def main():
 
 
 if __name__ == '__main__':
-    sys.exit(main() > 0)
+    sys.exit(int(main() > 0))
 

--- a/osg-token-renewer.service
+++ b/osg-token-renewer.service
@@ -7,11 +7,6 @@ Group=osg-token-svc
 Type = oneshot
 ExecStart = /usr/libexec/osg-token-renewer/osg-token-renewer.sh
 
-# These provide dedicated user with the ability to switch UIDs/GIDs for
-# reading/writing files.
-CapabilityBoundingSet=CAP_SETUID CAP_SETGID CAP_DAC_OVERRIDE
-AmbientCapabilities=CAP_SETGID CAP_SETUID CAP_DAC_OVERRIDE
-
 [Install]
 WantedBy=multi-user.target
 

--- a/osg-token-renewer.sh
+++ b/osg-token-renewer.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-if ! grep -q '^[[:space:]]*password_file[[:space:]]*=' /etc/osg/token-renewer/config.ini; then
+CONFIG_PATH="${OSG_TOKEN_RENEWER_CONFIG_PATH:-/etc/osg/token-renewer/config.ini}"
+
+if ! grep -q '^[[:space:]]*password_file[[:space:]]*=' "$CONFIG_PATH"; then
   # client credentials mode only
   exec "$(dirname "$0")"/osg-token-renewer
 fi

--- a/osg-token-renewer.sh
+++ b/osg-token-renewer.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if ! grep -q '^[[:space:]]*password_file[[:space:]]*=' /etc/osg/token-renewer/config.ini; then
+  # client credentials mode only
+  exec "$(dirname "$0")"/osg-token-renewer
+fi
+
 eval $(oidc-agent) >/dev/null
 "$(dirname "$0")"/osg-token-renewer
 oidc-agent -k >/dev/null

--- a/osg-token-renewer.timer
+++ b/osg-token-renewer.timer
@@ -1,11 +1,11 @@
 [Unit]
 Description=Timer for running OSG Token Renewer regularly
-   
+
 [Timer]
 OnBootSec=15min
 OnUnitActiveSec=10min
 RandomizedDelaySec=3min
 Unit=osg-token-renewer.service
-   
+
 [Install]
 WantedBy=multi-user.target

--- a/rpm/osg-token-renewer.spec
+++ b/rpm/osg-token-renewer.spec
@@ -1,13 +1,14 @@
 Name:      osg-token-renewer
-Summary:   oidc-agent token renewal service and timer
-Version:   0.9.0
+Summary:   token renewal service and timer using OIDC or client credentials
+Version:   1.0.0
 Release:   1%{?dist}
 License:   ASL 2.0
-URL:       http://www.opensciencegrid.org
+URL:       http://www.osg-htc.org
 BuildArch: noarch
 
 Source0:   %{name}-%{version}.tar.gz
 
+Requires:  %{name}-client = %{version}-%{release}
 Requires:  oidc-agent-cli >= 5.1.0
 
 %define svc_acct osg-token-svc
@@ -16,7 +17,16 @@ Requires:  oidc-agent-cli >= 5.1.0
 
 
 %description
-%summary
+
+%package client
+Summary:   token renewal service and timer using client credentials
+
+Requires:  jq
+Requires:  curl
+Requires:  python3-requests
+Requires:  python3-jwt
+
+%description client
 
 %prep
 %setup -q
@@ -29,7 +39,7 @@ find . -type f -exec \
 
 install -d $RPM_BUILD_ROOT/%{_sbindir}
 install -d $RPM_BUILD_ROOT/%{_libexecdir}/%{name}
-install -dm700 $RPM_BUILD_ROOT/%{_sysconfdir}/osg/tokens
+install -dm770 $RPM_BUILD_ROOT/%{_sysconfdir}/osg/tokens
 install -dm750 $RPM_BUILD_ROOT/%{_sysconfdir}/osg/token-renewer
 install -m 755 %{name}.py $RPM_BUILD_ROOT/%{_libexecdir}/%{name}/%{name}
 install -m 755 %{name}.sh $RPM_BUILD_ROOT/%{_libexecdir}/%{name}/%{name}.sh
@@ -38,13 +48,13 @@ install -m 640 config.ini $RPM_BUILD_ROOT/%{_sysconfdir}/osg/token-renewer
 install -d $RPM_BUILD_ROOT/%{_unitdir}
 install -m 644 %{name}.service $RPM_BUILD_ROOT/%{_unitdir}
 install -m 644 %{name}.timer $RPM_BUILD_ROOT/%{_unitdir}
-install -d -m 700 $RPM_BUILD_ROOT/%{_localstatedir}/spool/%svc_acct
+install -d -m 700 $RPM_BUILD_ROOT/%{_localstatedir}/spool/%{svc_acct}
 
 %pre
-getent group  %svc_acct >/dev/null || groupadd -r %svc_acct
-getent passwd %svc_acct >/dev/null || \
-       useradd -r -g %svc_acct -c "OSG Token Renewal Service" \
-       -s /sbin/nologin -d %{_localstatedir}/spool/%svc_acct %svc_acct
+getent group  %{svc_acct} >/dev/null || groupadd -r %{svc_acct}
+getent passwd %{svc_acct} >/dev/null || \
+       useradd -r -g %{svc_acct} -c "OSG Token Renewal Service" \
+       -s /sbin/nologin -d %{_localstatedir}/spool/%{svc_acct} %{svc_acct}
 
 %post
 /bin/systemctl daemon-reload >/dev/null 2>&1 || :
@@ -56,6 +66,9 @@ getent passwd %svc_acct >/dev/null || \
 
 
 %files
+# Empty intentionally; the main package is a metapackage
+
+%files client
 %defattr(-,root,root,-)
 %{_libexecdir}/%{name}/%{name}
 %{_libexecdir}/%{name}/%{name}.sh
@@ -63,14 +76,26 @@ getent passwd %svc_acct >/dev/null || \
 %{_unitdir}/%{name}.service
 %{_unitdir}/%{name}.timer
 
-%dir %{_sysconfdir}/osg/tokens
-%attr(-,root,%svc_acct) %config(noreplace) %{_sysconfdir}/osg/token-renewer/config.ini
-%attr(-,%svc_acct,%svc_acct) %dir %{_localstatedir}/spool/%svc_acct
+%attr(-,root,%{svc_acct}) %dir %{_sysconfdir}/osg/tokens
+%attr(-,root,%{svc_acct}) %config(noreplace) %{_sysconfdir}/osg/token-renewer/config.ini
+%attr(-,%{svc_acct},%{svc_acct}) %dir %{_localstatedir}/spool/%{svc_acct}
 
 %doc README.md
 
 
 %changelog
+* Wed Mar 25 2026 Dave Dykstra - 1.0.0-1
+- Add "--client-credentials" option to osg-token-renewer-setup which configures
+  a mode that directly connects with grant_type=client_credentials to an Oauth
+  token endpoint to fetch access tokens.
+- Move all the files into a osg-token-renewer-client subpackage that does
+  not require the oidc-agent package.  When oidc-agent is not installed, only
+  the client credentials mode works.
+- Change the group of the /etc/osg/tokens directory to osg-token-svc and make
+  the directory fully accessible to the osg-token-svc group. This enabled
+  removing the extra capabilities given to the systemd service, making it a
+  little more secure.
+
 * Wed Jan 31 2024 Dave Dykstra - 0.9.0-1
 - Require oidc-agent-cli-5.1.0, and use a new oidc-add --skip-check option
   there to avoid trying to get an access token at load time.  This avoids


### PR DESCRIPTION
This adds another mode to osg-token-renewer to directly contact a token issuer using `grant_type=client_credentials` in addition to its previous mode of using oidc-agent.

In order to allow for fewer dependencies for those only using the new mode, the files are moved to a new subpackage osg-token-renewer-client and osg-token-renewer is turned into a metapackage that just Requires the subpackage and oidc-agent.